### PR TITLE
Optimized session flow, corrected some PHP warnings

### DIFF
--- a/htdocs/api.php
+++ b/htdocs/api.php
@@ -24,17 +24,14 @@ $commands = json_decode($_POST['commands'],true);
 
 // authenticate session
 if ($session_id1) {
-	//db_start_transaction();
-	$result = db_query_array('SELECT sessions.session_key AS session_key, site_users.* FROM sessions LEFT JOIN site_users ON (sessions.user_id = site_users.id) WHERE sessions.session_id = '.$session_id1.' AND sessions.nonce <= '.($nonce1 + 5).' AND sessions.nonce >= '.($nonce1 - 5));
-	//db_commit();
-	//$result = db_query_array('SELECT sessions.session_key AS session_key, site_users.* FROM sessions LEFT JOIN site_users ON (sessions.user_id = site_users.id) WHERE sessions.session_id = '.$session_id1.' ');
-	if ($result) {
+	$result = db_query_array('SELECT sessions.nonce AS nonce ,sessions.session_key AS session_key, sessions.awaiting AS awaiting, site_users.* FROM sessions LEFT JOIN site_users ON (sessions.user_id = site_users.id) WHERE sessions.session_id = '.$session_id1);
+	if ($result && $result[0]['nonce'] >= ($nonce1 + 5) && $result[0]['nonce'] <= ($nonce1 - 5)) {
+		$return['error'] = 'invalid-nonce';
+	}
+	elseif ($result) {
 		if (openssl_verify($_POST['commands'],$signature1,$result[0]['session_key'])) {
 			User::setInfo($result[0]);
 			$update_nonce = true;
-			
-			if (User::$info['last_lang'] != $CFG->language)
-				db_update('site_users',User::$info['id'],array('last_lang'=>$CFG->language));
 			
 			if (User::$info['locked'] == 'Y' || User::$info['deactivated'] == 'Y') {
 				$return['error'] = 'account-locked-or-deactivated';
@@ -159,4 +156,3 @@ if ($update_nonce)
 if (is_array($return))
 	echo json_encode($return);
 
-//db_commit();

--- a/lib/Orders.php
+++ b/lib/Orders.php
@@ -1,6 +1,6 @@
 <?php
 class Orders {
-	function get($count=false,$page=false,$per_page=false,$currency=false,$user=false,$start_date=false,$show_bids=false,$order_by1=false,$order_desc=false,$dont_paginate=false,$public_api_open_orders=false,$public_api_order_book) {
+	function get($count=false,$page=false,$per_page=false,$currency=false,$user=false,$start_date=false,$show_bids=false,$order_by1=false,$order_desc=false,$dont_paginate=false,$public_api_open_orders=false,$public_api_order_book=false) {
 		global $CFG;
 		
 		if ($user && !(User::$info['id'] > 0))
@@ -263,7 +263,7 @@ class Orders {
 		return db_query_array($sql);
 	}
 	
-	private function triggerStops($max_price,$min_price,$currency,$maker_is_sell=false,$abs_bid=false,$abs_ask=false,$currency_max,$currency_min) {
+	private function triggerStops($max_price,$min_price,$currency,$maker_is_sell=false,$abs_bid=false,$abs_ask=false,$currency_max=false,$currency_min=false) {
 		global $CFG;
 		
 		$currency = preg_replace("/[^a-zA-Z]/", "",$currency);

--- a/lib/User.php
+++ b/lib/User.php
@@ -18,6 +18,68 @@ class User {
 		return $result[0];
 	}
 	
+	function verifyLogin() {
+		global $CFG;
+		
+		if (!($CFG->session_id > 0))
+			return false;
+		
+		if (!User::$info) {
+			return array('error'=>'session-not-found');
+		}
+		
+		if (User::$info['awaiting'] == 'Y') {
+			return array('message'=>'awaiting-token');
+		}
+		
+		$return_values = array(
+		'first_name',
+		'last_name',
+		'fee_schedule',
+		'tel',
+		'country',
+		'country_code',
+		'verified_google',
+		'verified_authy',
+		'using_sms',
+		'confirm_withdrawal_email_btc',
+		'confirm_withdrawal_2fa_btc',
+		'confirm_withdrawal_2fa_bank',
+		'confirm_withdrawal_email_bank',
+		'notify_deposit_btc',
+		'notify_deposit_bank',
+		'notify_withdraw_btc',
+		'notify_withdraw_bank',
+		'no_logins',
+		'notify_login',
+		'deactivated',
+		'locked',
+		'default_currency');
+		
+		$return = array();
+		foreach (User::$info as $key => $value) {
+			if (in_array($key,$return_values))
+				$return[$key] = $value;
+		}
+		
+		if ($return['country_code'] > 0) {
+			$s = strlen($return['country_code']);
+			$return['country_code'] = str_repeat('x',$s);
+		}
+		
+		if ($return['tel'] > 0) {
+			$s = strlen($return['tel']) - 2;
+			$return['tel'] = str_repeat('x',$s).substr($return['tel'], -2);
+		}
+		
+		if ($result['default_currency'] > 0) {
+			$currency = DB::getRecord('currencies',$result['default_currency'],0,1);
+			$return['default_currency_abbr'] = $currency['currency'];
+		}
+		
+		return array('message'=>'logged-in','info'=>$return);
+	}
+	
 	function logOut($session_id=false) {
 		if (!($session_id > 0))
 			return false;
@@ -571,6 +633,14 @@ class User {
 	function getCountries() {
 		$sql = "SELECT * FROM iso_countries ORDER BY name ASC";
 		return db_query_array($sql);
+	}
+	
+	function setLang($lang) {
+		if (!$lang)
+			return false;
+		
+		$lang = preg_replace("/[^a-z]/", "",$lang);
+		return db_update('site_users',User::$info['id'],array('last_lang'=>$lang));
 	}
 }
 


### PR DESCRIPTION
Solves #8 .

1) This class now verifies the existing frontend sessions.
2) Nonce is no longer used in WHERE clause of query when checking sessions.
3) Provided default values for functions in Orders class that were causing warnings to be logged in log files.

Requires DB update to v 1.03.
